### PR TITLE
Switch infrastructure configuration to Ubuntu 14.04

### DIFF
--- a/ec2-swarm/ansible.cfg
+++ b/ec2-swarm/ansible.cfg
@@ -1,7 +1,7 @@
 [defaults]
 inventory = ./ec2.py
 private_key_file = ~/.ssh/itx_rsa
-remote_user = centos
+remote_user = ubuntu
 host_key_checking = False
 
 [ssh_connection]

--- a/ec2-swarm/ansible.cfg
+++ b/ec2-swarm/ansible.cfg
@@ -2,7 +2,7 @@
 inventory = ./ec2.py
 private_key_file = ~/.ssh/itx_rsa
 remote_user = ubuntu
-host_key_checking = False
+host_key_checking = false
 
 [ssh_connection]
-ssh_args = -o PubKeyAuthentication=yes -o ControlMaster=auto -o ControlPersist=60s -o ControlPath=~/.ansible/cp/ansible-ssh-%h-%p-%r
+ssh_args = -o PubKeyAuthentication=yes -o ControlMaster=auto -o ControlPersist=60s -o ControlPath=~/.ansible/cp/ansible-ssh-%h-%p-%r -o UserKnownHostsFile=./known_hosts

--- a/ec2-swarm/create-swarm.yml
+++ b/ec2-swarm/create-swarm.yml
@@ -1,34 +1,65 @@
-- name: "Disable live restore on all nodes"
-  hosts: "us-west-2"
-  gather_facts: yes
-  tasks:
-    - lineinfile:
-        dest: "/etc/docker/daemon.json"
-        regexp: '^(    "live-restore"): true'
-        line: '\1: false'
-        backrefs: yes
-    - service:
-        name: "docker.service"
-        state: "restarted"
-  tags:
-    - manager
-    - worker
-    - preconfig
+---
+- hosts: "us-west-2"
+  become: "yes"
+  remote_user: "ubuntu"
 
-- name: "Initialize Docker Swarm manager"
-  hosts: tag_role_manager
-  gather_facts: yes
   tasks:
-    - command: "docker swarm init --advertise-addr {{ ansible_default_ipv4.address }}"
-    - command: "docker swarm join-token -q worker"
-      register: swarm_token
-    - set_fact: swarmtoken="{{ swarm_token.stdout }}"
-  tags:
-    - manager
+  - name: "Install Pip"
+    package:
+      name: "python-pip"
+      state: "present"
 
-- name: "Join worker nodes to Swarm cluster"
-  hosts: tag_role_worker
+  - name: "Install some Python modules"
+    pip:
+      name: "{{ item }}"
+      state: "present"
+    with_items:
+      - "urllib3"
+      - "pyopenssl"
+      - "ndg-httpsclient"
+      - "pyasn1"
+
+  - name: "Install Docker APT Key"
+    apt_key:
+      url: "https://download.docker.com/linux/ubuntu/gpg"
+      state: "present"
+
+  - name: "Add Docker repository"
+    apt_repository:
+      repo: "deb [arch=amd64] https://download.docker.com/linux/ubuntu trusty stable"
+      state: "present"
+      update_cache: "yes"
+
+  - name: "Install Docker CE"
+    package:
+      name: "docker-ce"
+      state: "present"
+
+  - name: "Add user to Docker group"
+    user:
+      name: "{{ ansible_ssh_user }}"
+      group: "docker"
+      append: "yes"
+
+- hosts: "tag_role_manager"
+  become: "yes"
+  remote_user: "ubuntu"
+
   tasks:
-    - command: "docker swarm join --advertise-addr {{ ansible_default_ipv4.address }} --token {{ hostvars[groups['tag_role_manager'][0]].swarmtoken }} {{ hostvars[groups['tag_role_manager'][0]].ansible_default_ipv4.address }}:2377"
-  tags:
-    - worker
+  - name: "Initialize Docker Swarm from manager"
+    command: "docker swarm init --advertise-addr {{ ansible_default_ipv4.address }}"
+
+  - name: "Register Swarm join token"
+    command: "docker swarm join-token -q worker"
+    register: swarm_token
+
+  - name: "Establish Swarm join token as a host fact"
+    set_fact: swarmtoken="{{ swarm_token.stdout }}"
+
+- hosts: "tag_role_worker"
+  become: "yes"
+  remote_user: "ubuntu"
+
+  tasks:
+  - name: "Join worker nodes to Swarm cluster"
+    command: "docker swarm join --advertise-addr {{ ansible_default_ipv4.address }} --token {{ hostvars[groups['tag_role_manager'][0]].swarmtoken }} {{ hostvars[groups['tag_role_manager'][0]].ansible_default_ipv4.address }}:2377"

--- a/ec2-swarm/data.tf
+++ b/ec2-swarm/data.tf
@@ -2,10 +2,14 @@ data "aws_ami" "swarm_ami" {
     most_recent             = true
     filter {
         name                = "name"
-        values              = ["*CentOS Atomic*"]
+        values              = ["*ubuntu-trusty-14.04*"]
     }
     filter {
         name                = "virtualization-type"
         values              = ["hvm"]
+    }
+    filter {
+        name                = "root-device-type"
+        values              = ["ebs"]
     }
 }

--- a/ec2-swarm/destroy-swarm.yml
+++ b/ec2-swarm/destroy-swarm.yml
@@ -1,5 +1,8 @@
-- name: "Leave Swarm cluster"
-  hosts: "us-west-2"
-  gather_facts: yes
+---
+- hosts: "us-west-2"
+  become: "yes"
+  remote_user: "ubuntu"
+
   tasks:
-    - command: "docker swarm leave --force"
+  - name: "Leave Swarm cluster"
+    command: "docker swarm leave --force"

--- a/ec2-swarm/security.tf
+++ b/ec2-swarm/security.tf
@@ -39,33 +39,15 @@ resource "aws_security_group" "swarm_sg" {
         protocol            = "tcp"
         cidr_blocks         = ["0.0.0.0/0"]
     }
-    egress {
-        from_port           = "0"
-        to_port             = "0"
-        protocol            = "-1"
-        cidr_blocks         = ["0.0.0.0/0"]
-    }
-    tags {
-        tool                = "terraform"
-        demo                = "ec2-swarm"
-        area                = "security"
-    }
-}
-
-# Create a security group to allow inbound SSH (for manager only)
-resource "aws_security_group" "web_sg" {
-    vpc_id                  = "${aws_vpc.ec2_swarm_vpc.id}"
-    name                    = "web-sg"
-    description             = "Security group for web traffic"
     ingress {
-        from_port           = "80"
-        to_port             = "80"
+        from_port           = "5000"
+        to_port             = "5001"
         protocol            = "tcp"
         cidr_blocks         = ["0.0.0.0/0"]
     }
     ingress {
-        from_port           = "443"
-        to_port             = "443"
+        from_port           = "8080"
+        to_port             = "8080"
         protocol            = "tcp"
         cidr_blocks         = ["0.0.0.0/0"]
     }

--- a/ec2-swarm/security.tf
+++ b/ec2-swarm/security.tf
@@ -4,33 +4,9 @@ resource "aws_security_group" "swarm_sg" {
     name                    = "swarm-sg"
     description             = "Security group for Swarm traffic"
     ingress {
-        from_port           = "2375"
-        to_port             = "2377"
-        protocol            = "tcp"
-        cidr_blocks         = ["${aws_vpc.ec2_swarm_vpc.cidr_block}"]
-    }
-    ingress {
-        from_port           = "7946"
-        to_port             = "7946"
-        protocol            = "tcp"
-        cidr_blocks         = ["${aws_vpc.ec2_swarm_vpc.cidr_block}"]
-    }
-    ingress {
-        from_port           = "7946"
-        to_port             = "7946"
-        protocol            = "udp"
-        cidr_blocks         = ["${aws_vpc.ec2_swarm_vpc.cidr_block}"]
-    }
-    ingress {
-        from_port           = "4789"
-        to_port             = "4789"
-        protocol            = "tcp"
-        cidr_blocks         = ["${aws_vpc.ec2_swarm_vpc.cidr_block}"]
-    }
-    ingress {
-        from_port           = "4789"
-        to_port             = "4789"
-        protocol            = "udp"
+        from_port           = "0"
+        to_port             = "0"
+        protocol            = "-1"
         cidr_blocks         = ["${aws_vpc.ec2_swarm_vpc.cidr_block}"]
     }
     ingress {

--- a/ec2-swarm/swarm.tf
+++ b/ec2-swarm/swarm.tf
@@ -1,7 +1,7 @@
 # Launch a CentOS Atomic Host instance to serve as Swarm manager
 resource "aws_instance" "manager" {
     ami                     = "${data.aws_ami.swarm_ami.id}"
-    instance_type           = "${var.flavor}"
+    instance_type           = "${var.mgr_flavor}"
     key_name                = "${var.keypair}"
     vpc_security_group_ids  = ["${aws_security_group.swarm_sg.id}"]
     subnet_id               = "${aws_subnet.ec2_swarm_public.id}"
@@ -18,10 +18,9 @@ resource "aws_instance" "manager" {
 resource "aws_instance" "worker" {
     ami                     = "${data.aws_ami.swarm_ami.id}"
     count                   = 3
-    instance_type           = "${var.flavor}"
+    instance_type           = "${var.wkr_flavor}"
     key_name                = "${var.keypair}"
-    vpc_security_group_ids  = ["${aws_security_group.swarm_sg.id}",
-                               "${aws_security_group.web_sg.id}"]
+    vpc_security_group_ids  = ["${aws_security_group.swarm_sg.id}"]
     subnet_id               = "${aws_subnet.ec2_swarm_public.id}"
     depends_on              = ["aws_internet_gateway.ec2_swarm_gw"]
     tags {

--- a/ec2-swarm/vars.tf
+++ b/ec2-swarm/vars.tf
@@ -4,7 +4,13 @@ variable "keypair" {
     default                 = "itx_rsa"
 }
 
-variable "flavor" {
+variable "mgr_flavor" {
+    type                    = "string"
+    description             = "AWS type to use when creating instances"
+    default                 = "t2.small"
+}
+
+variable "wkr_flavor" {
     type                    = "string"
     description             = "AWS type to use when creating instances"
     default                 = "t2.micro"


### PR DESCRIPTION
Convert the infrastructure to Ubuntu 14.04. While this is an older operating system, it has the right combination of supporting Docker 1.13 or higher (Docker CE 17.03 is used in the demo) as well as Python 2 (for Ansible support).